### PR TITLE
name word wrap (fixed)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -344,6 +344,11 @@ main {
   margin-bottom: 10px;
 }
 
+.name {
+  overflow: hidden;
+  overflow-wrap: break-word;
+}
+
 .info-content .title {
   color: var(--white-1);
   background: var(--onyx);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vcard-personal-portfolio",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Issue #42 has been fixed. From now on, if the name overflows, it will automatically be split into two lines.