### PR TITLE
[Fix] Sidebar active height above 1250px

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1833,6 +1833,10 @@ textarea.form-input::-webkit-resizer { display: none; }
     z-index: 1;
   }
 
+  .sidebar.active{
+    max-height: initial;
+  }
+  
   .sidebar-info { flex-direction: column; }
 
   .avatar-box img { width: 150px; }


### PR DESCRIPTION

Bug: If side bar is active and we come back to above 1250px. The sidebar height still stays at 584px. 

![Bug](https://github.com/codewithsadee/vcard-personal-portfolio/assets/68629215/9d5f2652-03bd-4bd3-b7cc-14e13cebb036)

Fix: Made max-height: initial above 1250px.

![Fix](https://github.com/codewithsadee/vcard-personal-portfolio/assets/68629215/0daff804-2f92-432e-be01-20da316c78b0)

Let me know if this has any affect on existing design.
This is my first contribution to a open source public repository🙂

Thank you! 