### PR TITLE
Fix CDN for ionicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1193,8 +1193,8 @@
   <!--
     - ionicon link
   -->
-  <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
-  <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.js"></script>
 
 </body>
 


### PR DESCRIPTION
It seems like ionicons changed their CDN, which resulted in ionicons not showing. this PR updates the CDN link with the new CDN.